### PR TITLE
Add Flatpak packaging support

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ Complete documentation is available at [fastforge.dev](https://fastforge.dev/).
 - **Android**: [AAB](https://fastforge.dev/en/makers/aab), [APK](https://fastforge.dev/en/makers/apk)
 - **iOS**: [IPA](https://fastforge.dev/en/makers/ipa)
 - **OpenHarmony**: [HAP](https://fastforge.dev/en/makers/hap), [APP](https://fastforge.dev/en/makers/app)
-- **Linux**: [AppImage](https://fastforge.dev/en/makers/appimage), [DEB](https://fastforge.dev/en/makers/deb), [RPM](https://fastforge.dev/en/makers/rpm), Pacman
+ - **Linux**: [AppImage](https://fastforge.dev/en/makers/appimage), [DEB](https://fastforge.dev/en/makers/deb), [RPM](https://fastforge.dev/en/makers/rpm), [Flatpak](https://fastforge.dev/en/makers/flatpak), Pacman
 - **macOS**: [DMG](https://fastforge.dev/en/makers/dmg), [PKG](https://fastforge.dev/en/makers/pkg)
 - **Windows**: [EXE](https://fastforge.dev/en/makers/exe), [MSIX](https://fastforge.dev/en/makers/msix)
 - **Universal**: [ZIP](https://fastforge.dev/en/makers/zip)

--- a/docs/.vitepress/config/en.ts
+++ b/docs/.vitepress/config/en.ts
@@ -65,6 +65,7 @@ function sidebarGuide(): DefaultTheme.SidebarItem[] {
         { text: 'msix', link: 'makers/msix' },
         { text: 'pkg', link: 'makers/pkg' },
         { text: 'rpm', link: 'makers/rpm' },
+        { text: 'flatpak', link: 'makers/flatpak' },
         { text: 'zip', link: 'makers/zip' },
       ],
     },

--- a/docs/.vitepress/config/zh.ts
+++ b/docs/.vitepress/config/zh.ts
@@ -90,6 +90,7 @@ function sidebarGuide(): DefaultTheme.SidebarItem[] {
         { text: 'msix', link: 'makers/msix' },
         { text: 'pkg', link: 'makers/pkg' },
         { text: 'rpm', link: 'makers/rpm' },
+        { text: 'flatpak', link: 'makers/flatpak' },
         { text: 'zip', link: 'makers/zip' },
       ],
     },

--- a/docs/en/makers/flatpak.md
+++ b/docs/en/makers/flatpak.md
@@ -1,0 +1,32 @@
+# flatpak
+
+## Requires
+
+- `flatpak`
+- `flatpak-builder`
+
+Install requirements on Ubuntu/Debian:
+
+```bash
+sudo apt install flatpak flatpak-builder
+```
+
+## Usage
+
+Add `make_config.yaml` to your project `linux/packaging/flatpak` directory.
+
+```yaml
+app_id: com.example.app
+runtime: org.freedesktop.Platform
+runtime_version: '23.08'
+sdk: org.freedesktop.Sdk
+finish_args:
+  - --share=network
+  - --filesystem=home
+```
+
+Run:
+
+```bash
+fastforge package --platform linux --targets flatpak
+```

--- a/docs/zh/makers/flatpak.md
+++ b/docs/zh/makers/flatpak.md
@@ -1,0 +1,32 @@
+# flatpak
+
+## 依赖
+
+- `flatpak`
+- `flatpak-builder`
+
+在 Ubuntu/Debian 上安装依赖:
+
+```bash
+sudo apt install flatpak flatpak-builder
+```
+
+## 使用方法
+
+在项目 `linux/packaging/flatpak` 目录下添加 `make_config.yaml`:
+
+```yaml
+app_id: com.example.app
+runtime: org.freedesktop.Platform
+runtime_version: '23.08'
+sdk: org.freedesktop.Sdk
+finish_args:
+  - --share=network
+  - --filesystem=home
+```
+
+执行:
+
+```bash
+fastforge package --platform linux --targets flatpak
+```

--- a/examples/hello_world/distribute_options.yaml
+++ b/examples/hello_world/distribute_options.yaml
@@ -56,6 +56,12 @@ releases:
           target: pacman
           build_args:
             profile: true
+      - name: linux-flatpak
+        package:
+          platform: linux
+          target: flatpak
+          build_args:
+            profile: true
       - name: linux-zip
         package:
           platform: linux
@@ -131,6 +137,10 @@ releases:
         package:
           platform: linux
           target: deb
+      - name: linux-flatpak
+        package:
+          platform: linux
+          target: flatpak
       - name: linux-zip
         package:
           platform: linux

--- a/examples/hello_world/linux/packaging/flatpak/make_config.yaml
+++ b/examples/hello_world/linux/packaging/flatpak/make_config.yaml
@@ -1,0 +1,7 @@
+app_id: dev.fastforge.hello_world
+runtime: org.freedesktop.Platform
+runtime_version: '23.08'
+sdk: org.freedesktop.Sdk
+finish_args:
+  - --share=network
+  - --filesystem=home

--- a/packages/flutter_app_packager/lib/src/flutter_app_packager.dart
+++ b/packages/flutter_app_packager/lib/src/flutter_app_packager.dart
@@ -21,6 +21,7 @@ class FlutterAppPackager {
     AppPackageMakerMsix(),
     AppPackageMakerPkg(),
     AppPackageMakerRPM(),
+    AppPackageMakerFlatpak(),
     AppPackageMakerPacman(),
     AppPackageMakerZip('linux'),
     AppPackageMakerZip('macos'),

--- a/packages/flutter_app_packager/lib/src/makers/flatpak/app_package_maker_flatpak.dart
+++ b/packages/flutter_app_packager/lib/src/makers/flatpak/app_package_maker_flatpak.dart
@@ -1,0 +1,72 @@
+import 'dart:io';
+
+import 'package:flutter_app_packager/src/api/app_package_maker.dart';
+import 'package:flutter_app_packager/src/makers/flatpak/make_flatpak_config.dart';
+import 'package:path/path.dart' as path;
+import 'package:shell_executor/shell_executor.dart';
+
+class AppPackageMakerFlatpak extends AppPackageMaker {
+  @override
+  String get name => 'flatpak';
+  @override
+  String get platform => 'linux';
+  @override
+  bool get isSupportedOnCurrentPlatform => Platform.isLinux;
+  @override
+  String get packageFormat => 'flatpak';
+
+  @override
+  MakeConfigLoader get configLoader {
+    return MakeFlatpakConfigLoader()
+      ..platform = platform
+      ..packageFormat = packageFormat;
+  }
+
+  @override
+  Future<MakeResult> make(MakeConfig config) {
+    return _make(
+      config.buildOutputDirectory,
+      outputDirectory: config.outputDirectory,
+      makeConfig: config as MakeFlatpakConfig,
+    );
+  }
+
+  Future<MakeResult> _make(
+    Directory appDirectory, {
+    required Directory outputDirectory,
+    required MakeFlatpakConfig makeConfig,
+  }) async {
+    final packagingDirectory = makeConfig.packagingDirectory;
+    final appDir = Directory(path.join(packagingDirectory.path, 'app'));
+    await $('cp', ['-fr', '${appDirectory.path}/.', appDir.path]);
+
+    final manifestFile = File(path.join(packagingDirectory.path, 'manifest.yml'))
+      ..writeAsStringSync(
+        makeConfig.manifestContent(makeConfig.appBinaryName),
+      );
+
+    final buildDir = Directory(path.join(packagingDirectory.path, 'build'));
+    final repoDir = Directory(path.join(packagingDirectory.path, 'repo'));
+    buildDir.createSync(recursive: true);
+    repoDir.createSync(recursive: true);
+
+    var result = await $('flatpak-builder', [
+      '--force-clean',
+      buildDir.path,
+      manifestFile.path,
+    ]);
+    if (result.exitCode != 0) throw MakeError();
+
+    result = await $('flatpak', [
+      'build-bundle',
+      repoDir.path,
+      makeConfig.outputFile.path,
+      makeConfig.appId,
+      config.appVersion.toString(),
+    ]);
+    if (result.exitCode != 0) throw MakeError();
+
+    packagingDirectory.deleteSync(recursive: true);
+    return MakeResult(makeConfig);
+  }
+}

--- a/packages/flutter_app_packager/lib/src/makers/flatpak/make_flatpak_config.dart
+++ b/packages/flutter_app_packager/lib/src/makers/flatpak/make_flatpak_config.dart
@@ -1,0 +1,69 @@
+import 'dart:io';
+
+import 'package:flutter_app_packager/src/api/app_package_maker.dart';
+
+class MakeFlatpakConfig extends MakeLinuxPackageConfig {
+  MakeFlatpakConfig({
+    required this.appId,
+    this.runtime = 'org.freedesktop.Platform',
+    this.runtimeVersion = '23.08',
+    this.sdk = 'org.freedesktop.Sdk',
+    List<String>? finishArgs,
+  }) : finishArgs = finishArgs ?? const ['--share=network', '--filesystem=home'];
+
+  factory MakeFlatpakConfig.fromJson(Map<String, dynamic> map) {
+    return MakeFlatpakConfig(
+      appId: map['app_id'] as String,
+      runtime: map['runtime'] as String? ?? 'org.freedesktop.Platform',
+      runtimeVersion: map['runtime_version'] as String? ?? '23.08',
+      sdk: map['sdk'] as String? ?? 'org.freedesktop.Sdk',
+      finishArgs: (map['finish_args'] as List?)?.cast<String>(),
+    );
+  }
+
+  final String appId;
+  final String runtime;
+  final String runtimeVersion;
+  final String sdk;
+  final List<String> finishArgs;
+
+  String manifestContent(String binaryName) {
+    final finish = finishArgs.map((e) => '  - $e').join('\n');
+    return '''
+app-id: $appId
+runtime: $runtime
+runtime-version: $runtimeVersion
+sdk: $sdk
+command: $binaryName
+finish-args:
+$finish
+modules:
+  - name: $appId
+    buildsystem: simple
+    sources:
+      - type: dir
+        path: app
+''';
+  }
+}
+
+class MakeFlatpakConfigLoader extends DefaultMakeConfigLoader {
+  @override
+  MakeConfig load(
+    Map<String, dynamic>? arguments,
+    Directory outputDirectory, {
+    required Directory buildOutputDirectory,
+    required List<File> buildOutputFiles,
+  }) {
+    final baseMakeConfig = super.load(
+      arguments,
+      outputDirectory,
+      buildOutputDirectory: buildOutputDirectory,
+      buildOutputFiles: buildOutputFiles,
+    );
+    final map = loadMakeConfigYaml(
+      '$platform/packaging/$packageFormat/make_config.yaml',
+    );
+    return MakeFlatpakConfig.fromJson(map).copyWith(baseMakeConfig);
+  }
+}

--- a/packages/flutter_app_packager/lib/src/makers/makers.dart
+++ b/packages/flutter_app_packager/lib/src/makers/makers.dart
@@ -12,3 +12,4 @@ export 'msix/app_package_maker_msix.dart';
 export 'pkg/app_package_maker_pkg.dart';
 export 'rpm/app_package_maker_rpm.dart';
 export 'zip/app_package_maker_zip.dart';
+export 'flatpak/app_package_maker_flatpak.dart';

--- a/packages/unified_distributor/lib/src/cli/command_package.dart
+++ b/packages/unified_distributor/lib/src/cli/command_package.dart
@@ -34,6 +34,7 @@ class CommandPackage extends Command {
         'app',
         'appimage',
         'deb',
+        'flatpak',
         'dmg',
         'exe',
         'hap',


### PR DESCRIPTION
## Summary
- add Flatpak packaging maker and config
- register Flatpak maker with FlutterAppPackager
- document Flatpak maker in English and Chinese docs
- expose Flatpak option in CLI and docs sidebar
- provide sample config and usage in example project

## Testing
- `melos run analyze` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_684ebf72af1c832fb562f31301871dc8