### PR TITLE
Add parent make_config.yaml support

### DIFF
--- a/docs/en/makers/appimage.md
+++ b/docs/en/makers/appimage.md
@@ -25,6 +25,7 @@ mv appimagetool /usr/local/bin/
 ## Usage
 
 Add `make_config.yaml` to your project `linux/packaging/appimage` directory.
+If a `linux/packaging/make_config.yaml` file exists, its values will be merged as defaults.
 
 ```yaml
 display_name: Hello World

--- a/docs/en/makers/deb.md
+++ b/docs/en/makers/deb.md
@@ -1,6 +1,8 @@
 # deb
 
 Add `make_config.yaml` to your project `linux/packaging/deb` directory.
+If a `linux/packaging/make_config.yaml` file exists, its values will be used as
+defaults and merged with the package specific file.
 
 ```yaml
 display_name: Hello World

--- a/docs/en/makers/dmg.md
+++ b/docs/en/makers/dmg.md
@@ -15,6 +15,7 @@ npm install -g appdmg
 ## Usage
 
 Add `make_config.yaml` to your project `macos/packaging/dmg` directory.
+You can also create a `macos/packaging/make_config.yaml` with shared defaults.
 
 ```yaml
 title: hello_world

--- a/docs/en/makers/exe.md
+++ b/docs/en/makers/exe.md
@@ -7,6 +7,7 @@
 ## Usage
 
 Add `make_config.yaml` to your project `windows/packaging/exe` directory.
+Place a `windows/packaging/make_config.yaml` file to define defaults for all Windows packages.
 
 ```yaml
 # The value of AppId uniquely identifies this application.

--- a/docs/en/makers/msix.md
+++ b/docs/en/makers/msix.md
@@ -3,6 +3,7 @@
 ## Usage
 
 Add `make_config.yaml` to your project `windows/packaging/msix` directory.
+Common settings can be placed in `windows/packaging/make_config.yaml`.
 
 ```yaml
 display_name: HelloWorld

--- a/docs/en/makers/pkg.md
+++ b/docs/en/makers/pkg.md
@@ -5,6 +5,7 @@
 ## Usage
 
 Add `make_config.yaml` to your project `macos/packaging/pkg` directory.
+Defaults may also come from `macos/packaging/make_config.yaml`.
 
 ```yaml
 install-path: /Applications

--- a/docs/en/makers/rpm.md
+++ b/docs/en/makers/rpm.md
@@ -14,6 +14,7 @@ Install requirements:
 ## Usage
 
 Add `make_config.yaml` to your project `linux/packaging/rpm` directory.
+A `linux/packaging/make_config.yaml` can provide default settings for all Linux packages.
 
 ```yaml
 icon: assets/logo.png

--- a/docs/zh/makers/appimage.md
+++ b/docs/zh/makers/appimage.md
@@ -25,6 +25,7 @@ mv appimagetool /usr/local/bin/
 ## 用法
 
 将 `make_config.yaml` 添加到您的项目 `linux/packaging/appimage` 目录。
+如果存在 `linux/packaging/make_config.yaml`，其配置会作为默认值被合并。
 
 ```yaml
 display_name: Hello World

--- a/docs/zh/makers/deb.md
+++ b/docs/zh/makers/deb.md
@@ -1,6 +1,7 @@
 # deb
 
 将 `make_config.yaml` 添加到您的项目 `linux/packaging/deb` 目录。
+如果存在 `linux/packaging/make_config.yaml`，其值会与当前文件合并作为默认设置。
 
 ```yaml
 display_name: Hello World

--- a/docs/zh/makers/dmg.md
+++ b/docs/zh/makers/dmg.md
@@ -15,6 +15,7 @@ npm install -g appdmg
 ## 用法
 
 将 `make_config.yaml` 添加到你的项目 `macos/packaging/dmg` 目录。
+你也可以在 `macos/packaging/make_config.yaml` 中设置通用默认值。
 
 ```yaml
 title: hello_world

--- a/docs/zh/makers/exe.md
+++ b/docs/zh/makers/exe.md
@@ -7,6 +7,7 @@
 ## 用法
 
 将 `make_config.yaml` 添加到你的项目 `windows/packaging/exe` 目录。
+可以在 `windows/packaging/make_config.yaml` 中定义所有 Windows 包的默认值。
 
 ```yaml
 # AppId 的值唯一标识此应用。

--- a/docs/zh/makers/msix.md
+++ b/docs/zh/makers/msix.md
@@ -3,6 +3,7 @@
 ## 用法
 
 将 `make_config.yaml` 添加到你的项目 `windows/packaging/msix` 目录。
+通用设置可以写在 `windows/packaging/make_config.yaml` 中。
 
 ```yaml
 display_name: HelloWorld

--- a/docs/zh/makers/pkg.md
+++ b/docs/zh/makers/pkg.md
@@ -5,6 +5,7 @@
 ## 用法
 
 将 `make_config.yaml` 添加到你的项目 `macos/packaging/pkg` 目录。
+也可以在 `macos/packaging/make_config.yaml` 中提供默认值。
 
 ```yaml
 install-path: /Applications

--- a/docs/zh/makers/rpm.md
+++ b/docs/zh/makers/rpm.md
@@ -14,6 +14,7 @@
 ## 用法
 
 将 `make_config.yaml` 添加到您的项目 `linux/packaging/rpm` 目录。
+`linux/packaging/make_config.yaml` 文件中的配置会作为所有 Linux 包的默认值。
 
 ```yaml
 icon: assets/logo.png

--- a/packages/flutter_app_packager/lib/src/api/app_package_maker.dart
+++ b/packages/flutter_app_packager/lib/src/api/app_package_maker.dart
@@ -10,9 +10,36 @@ export 'make_config.dart';
 export 'make_error.dart';
 export 'make_result.dart';
 
-Map<String, dynamic> loadMakeConfigYaml(String path) {
+Map<String, dynamic> _mergeYamlMap(
+  Map<String, dynamic> parent,
+  Map<String, dynamic> child,
+) {
+  final result = Map<String, dynamic>.from(parent);
+  child.forEach((key, value) {
+    if (value is Map && result[key] is Map) {
+      result[key] = _mergeYamlMap(
+        Map<String, dynamic>.from(result[key] as Map),
+        Map<String, dynamic>.from(value as Map),
+      );
+    } else {
+      result[key] = value;
+    }
+  });
+  return result;
+}
+
+Map<String, dynamic> loadMakeConfigYaml(
+  String path, {
+  String? parentPath,
+}) {
+  Map<String, dynamic> map = {};
+  if (parentPath != null && File(parentPath).existsSync()) {
+    final parentDoc = loadYaml(File(parentPath).readAsStringSync());
+    map = json.decode(json.encode(parentDoc));
+  }
   final yamlDoc = loadYaml(File(path).readAsStringSync());
-  return json.decode(json.encode(yamlDoc));
+  final childMap = json.decode(json.encode(yamlDoc));
+  return _mergeYamlMap(map, childMap);
 }
 
 abstract class AppPackageMaker {

--- a/packages/flutter_app_packager/lib/src/makers/appimage/make_appimage_config.dart
+++ b/packages/flutter_app_packager/lib/src/makers/appimage/make_appimage_config.dart
@@ -132,6 +132,7 @@ class MakeAppImageConfigLoader extends DefaultMakeConfigLoader {
     );
     final map = loadMakeConfigYaml(
       '$platform/packaging/$packageFormat/make_config.yaml',
+      parentPath: '$platform/packaging/make_config.yaml',
     );
     return MakeAppImageConfig.fromJson(map).copyWith(baseMakeConfig);
   }

--- a/packages/flutter_app_packager/lib/src/makers/deb/make_deb_config.dart
+++ b/packages/flutter_app_packager/lib/src/makers/deb/make_deb_config.dart
@@ -368,6 +368,7 @@ class MakeDebConfigLoader extends DefaultMakeConfigLoader {
     );
     final map = loadMakeConfigYaml(
       '$platform/packaging/$packageFormat/make_config.yaml',
+      parentPath: '$platform/packaging/make_config.yaml',
     );
     return MakeDebConfig.fromJson(map).copyWith(baseMakeConfig);
   }

--- a/packages/flutter_app_packager/lib/src/makers/dmg/make_dmg_config.dart
+++ b/packages/flutter_app_packager/lib/src/makers/dmg/make_dmg_config.dart
@@ -207,6 +207,7 @@ class MakeDmgConfigLoader extends DefaultMakeConfigLoader {
     );
     final map = loadMakeConfigYaml(
       '$platform/packaging/$packageFormat/make_config.yaml',
+      parentPath: '$platform/packaging/make_config.yaml',
     );
     return MakeDmgConfig.fromJson(map).copyWith(baseMakeConfig);
   }

--- a/packages/flutter_app_packager/lib/src/makers/exe/make_exe_config.dart
+++ b/packages/flutter_app_packager/lib/src/makers/exe/make_exe_config.dart
@@ -113,6 +113,7 @@ class MakeExeConfigLoader extends DefaultMakeConfigLoader {
     );
     final map = loadMakeConfigYaml(
       '$platform/packaging/$packageFormat/make_config.yaml',
+      parentPath: '$platform/packaging/make_config.yaml',
     );
     return MakeExeConfig.fromJson(map).copyWith(baseMakeConfig)
       ..isInstaller = true;

--- a/packages/flutter_app_packager/lib/src/makers/msix/make_msix_config.dart
+++ b/packages/flutter_app_packager/lib/src/makers/msix/make_msix_config.dart
@@ -183,6 +183,7 @@ class MakeMsixConfigLoader extends DefaultMakeConfigLoader {
     );
     final map = loadMakeConfigYaml(
       '$platform/packaging/$packageFormat/make_config.yaml',
+      parentPath: '$platform/packaging/make_config.yaml',
     );
     return MakeMsixConfig.fromJson(map).copyWith(baseMakeConfig);
   }

--- a/packages/flutter_app_packager/lib/src/makers/pacman/make_pacman_config.dart
+++ b/packages/flutter_app_packager/lib/src/makers/pacman/make_pacman_config.dart
@@ -318,6 +318,7 @@ class MakePacmanConfigLoader extends DefaultMakeConfigLoader {
     );
     final map = loadMakeConfigYaml(
       '$platform/packaging/$packageFormat/make_config.yaml',
+      parentPath: '$platform/packaging/make_config.yaml',
     );
     return MakePacmanConfig.fromJson(map).copyWith(baseMakeConfig);
   }

--- a/packages/flutter_app_packager/lib/src/makers/pkg/make_pkg_config.dart
+++ b/packages/flutter_app_packager/lib/src/makers/pkg/make_pkg_config.dart
@@ -42,6 +42,7 @@ class MakePkgConfigLoader extends DefaultMakeConfigLoader {
     );
     final map = loadMakeConfigYaml(
       '$platform/packaging/$packageFormat/make_config.yaml',
+      parentPath: '$platform/packaging/make_config.yaml',
     );
     return MakePkgConfig.fromJson(map).copyWith(baseMakeConfig);
   }

--- a/packages/flutter_app_packager/lib/src/makers/rpm/make_rpm_config.dart
+++ b/packages/flutter_app_packager/lib/src/makers/rpm/make_rpm_config.dart
@@ -224,6 +224,7 @@ class MakeRpmConfigLoader extends DefaultMakeConfigLoader {
     );
     final map = loadMakeConfigYaml(
       '$platform/packaging/$packageFormat/make_config.yaml',
+      parentPath: '$platform/packaging/make_config.yaml',
     );
     return MakeRPMConfig.fromJson(map).copyWith(baseMakeConfig);
   }

--- a/packages/flutter_app_packager/test/src/api/make_config_test.dart
+++ b/packages/flutter_app_packager/test/src/api/make_config_test.dart
@@ -41,5 +41,23 @@ void main() {
         'dist/1.0.0+1/test_app-1.0.0+1-android.apk',
       );
     });
+
+    test('loadMakeConfigYaml merges parent', () {
+      final tempDir = Directory.systemTemp.createTempSync();
+      final parentFile = File('${tempDir.path}/parent.yaml')
+        ..writeAsStringSync(
+            'maintainer:\n  name: Foo\n  email: foo@ex.com\npackage_name: parent');
+      final childFile = File('${tempDir.path}/child.yaml')
+        ..writeAsStringSync('maintainer:\n  email: bar@ex.com');
+
+      final map = loadMakeConfigYaml(
+        childFile.path,
+        parentPath: parentFile.path,
+      );
+
+      expect(map['package_name'], 'parent');
+      expect((map['maintainer'] as Map)['name'], 'Foo');
+      expect((map['maintainer'] as Map)['email'], 'bar@ex.com');
+    });
   });
 }


### PR DESCRIPTION
## Summary
- allow loading defaults from `<platform>/packaging/make_config.yaml`
- merge parent configuration into specific package configs
- document new behaviour in English and Chinese maker docs
- test new `loadMakeConfigYaml` merging logic

## Testing
- `dart pub get` for each package
- `dart test` for packages with tests

------
https://chatgpt.com/codex/tasks/task_e_6852491eb9d8832f8f7cdd0a32ef3ab0